### PR TITLE
Adding support for the file: namespace

### DIFF
--- a/lib/bond.js
+++ b/lib/bond.js
@@ -27,7 +27,7 @@ function resolve(path, options, mod) {
       } else if (namespace === "http" || namespace === "https") {
         return resolveHttp(path, options, mod)
       } else if (namespace === "file") {
-        return resolveFile(p, mod)
+        return resolveFile(p, options, mod)
       } else {
         throw new Error("Unable to resolve path: '" + path + "'. Unknown namespace: " + namespace)  
       }
@@ -108,20 +108,28 @@ function resolveFilename(path, mod) {
 /*******************************************************************************
  * resolveFile
  */
-function resolveFile(path, mod) {
+function resolveFile(path, options, mod) {
   if(path) {
     var f = Object()
     Object.defineProperties(f, {
-      stream: {
-        enumerable: false,
+      readStream: {
+        enumerable: true,
         configurable: false,
         writeable: false,
         get: function() {
           return fs.createReadStream(path)
         }
       },
+      writeStream: {
+        enumerable: true,
+        configurable: false,
+        writeable: false,
+        get: function() {
+          return fs.createWriteStream(path, {flags: "a"})
+        }
+      },
       content: {
-        enumerable: false,
+        enumerable: true,
         configurable: false,
         writeable: false,
         get: function() {
@@ -131,6 +139,34 @@ function resolveFile(path, mod) {
     })
     f.toString = function() {
       return this.content
+    }
+    /* open([flags][, mode][, callback])
+     */
+    f.open = function() {
+      var flags = "r"
+      var mode = null
+      var cb = null
+      if(arguments && arguments.length) {
+        for(var i in arguments) {
+          var arg = arguments[i]
+          switch(typeof arg) {
+            case "number":
+              mode = arg
+              break
+            case "string":
+              flags = arg
+              break
+            case "function":
+              cb = arg
+              break
+          }
+        }
+      }
+      if(cb) {
+        fs.open(path, flags, mode, cb)
+      } else {
+        return fs.openSync(path, flags, mode)
+      }
     }
     return f
   } else {

--- a/lib/bond.js
+++ b/lib/bond.js
@@ -27,7 +27,7 @@ function resolve(path, options, mod) {
       } else if (namespace === "http" || namespace === "https") {
         return resolveHttp(path, options, mod)
       } else if (namespace === "file") {
-        return resolveFileContent(p, mod)
+        return resolveFile(p, mod)
       } else {
         throw new Error("Unable to resolve path: '" + path + "'. Unknown namespace: " + namespace)  
       }
@@ -106,11 +106,33 @@ function resolveFilename(path, mod) {
 }
 
 /*******************************************************************************
- * resolveFileContent
+ * resolveFile
  */
-function resolveFileContent(path, mod) {
+function resolveFile(path, mod) {
   if(path) {
-    return fs.readFileSync(path).toString()
+    var f = Object()
+    Object.defineProperties(f, {
+      stream: {
+        enumerable: false,
+        configurable: false,
+        writeable: false,
+        get: function() {
+          return fs.createReadStream(path)
+        }
+      },
+      content: {
+        enumerable: false,
+        configurable: false,
+        writeable: false,
+        get: function() {
+          return fs.readFile.sync(path).toString()
+        }
+      }
+    })
+    f.toString = function() {
+      return this.content
+    }
+    return f
   } else {
     throw(Error("File not found: "+path))
   }

--- a/lib/bond.js
+++ b/lib/bond.js
@@ -140,26 +140,23 @@ function resolveFile(path, options, mod) {
     f.toString = function() {
       return this.content
     }
-    /* open([flags][, mode][, callback])
+    /* open(flags[, mode][, callback])
      */
     f.open = function() {
-      var flags = "r"
+      if(!arguments || arguments.length < 1) {
+        throw(Error("flags argument is required"))
+      }
+      var flags = arguments[0]
       var mode = null
       var cb = null
-      if(arguments && arguments.length) {
-        for(var i in arguments) {
-          var arg = arguments[i]
-          switch(typeof arg) {
-            case "number":
-              mode = arg
-              break
-            case "string":
-              flags = arg
-              break
-            case "function":
-              cb = arg
-              break
-          }
+      if(arguments.length > 2) {
+        mode = arguments[1]
+        cb = arguments[2]
+      } else if(arguments.length > 1) {
+        if(typeof arguments[1] === "number") {
+          mode = arguments[1]
+        } else {
+          cb = arguments[1]
         }
       }
       if(cb) {

--- a/lib/bond.js
+++ b/lib/bond.js
@@ -1,3 +1,5 @@
+var fs = require('fs')
+
 var Module = require('module')
 
 var CarbonClient = require('@carbon-io/carbon-client-node')
@@ -24,6 +26,8 @@ function resolve(path, options, mod) {
         return resolveEnv(p, options, mod)
       } else if (namespace === "http" || namespace === "https") {
         return resolveHttp(path, options, mod)
+      } else if (namespace === "file") {
+        return resolveFileContent(p, mod)
       } else {
         throw new Error("Unable to resolve path: '" + path + "'. Unknown namespace: " + namespace)  
       }
@@ -99,6 +103,17 @@ function resolveFilename(path, mod) {
   }
   
   return result
+}
+
+/*******************************************************************************
+ * resolveFileContent
+ */
+function resolveFileContent(path, mod) {
+  if(path) {
+    return fs.readFileSync(path).toString()
+  } else {
+    throw(Error("File not found: "+path))
+  }
 }
 
 /*******************************************************************************


### PR DESCRIPTION
This patch adds support for the "file:" namespace which resolves a file path into a string of its contents.  Not much else to it.  The problem with this is that large files will not fit into memory.  Some better implementation ideas:

1. Return a stream instead of a string
2. Return a custom object that can be used like a stream or easily resolved into a string if desired (e.g. `_o("file:foo/bar.txt").toString()`)
3. Add a separate namespace that returns a stream instead of a string, e.g. "fileStream:"